### PR TITLE
Fixed check "transitionend" event

### DIFF
--- a/src/angular-ui-notification.js
+++ b/src/angular-ui-notification.js
@@ -66,6 +66,7 @@ angular.module('ui-notification').factory('Notification', function(
 			var templateElement = $compile(template)(scope);
 			templateElement.addClass(args.type);
 			templateElement.bind('webkitTransitionEnd oTransitionEnd otransitionend transitionend msTransitionEnd click', function(e){
+				e = e.originalEvent || e;
 				if (e.type === 'click' || (e.propertyName === 'opacity' && e.elapsedTime >= 1)){
 					templateElement.remove();
 					messageElements.splice(messageElements.indexOf(templateElement), 1);


### PR DESCRIPTION
After auto hiding a notification, message isn't deleted. This pull request fixes it.