### PR TITLE
Re-arranged less files to that less file can be @imported into another project. Added variable for border radius.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ var banner = ['/**',
 
   // ==== Styles
 gulp.task('styles', function() {
-    gulp.src('src/angular-ui-notification.less')
+    gulp.src('src/build.less')
         .pipe(less({
             strictMath: true
         }))

--- a/src/angular-ui-notification.less
+++ b/src/angular-ui-notification.less
@@ -1,8 +1,7 @@
-@import "../bower_components/bootstrap/less/variables.less";
-@import "../bower_components/bootstrap/less/mixins.less";
-
+@ui-notification-border-radius: 0px;
 
 .ui-notification {
+    border-radius: @ui-notification-border-radius;
     position: fixed;
     z-index: 9999;
     box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.3);

--- a/src/build.less
+++ b/src/build.less
@@ -1,0 +1,3 @@
+@import "../bower_components/bootstrap/less/variables.less";
+@import "../bower_components/bootstrap/less/mixins.less";
+@import "angular-ui-notification.less";


### PR DESCRIPTION
The @import statements for bootstrap less files in the main less file require bootstrap to be installed under the project directory. Moved less bootstrap @import statements into separate build.less file so that angular-ui-notification.less can be imported into another project as-is, without needing to run bower install under the project directory. Added variable @ui-notification-border-radius for notification CSS border radius, default is 0px.