### PR TITLE
Fix an exception on null args

### DIFF
--- a/dist/angular-ui-notification.js
+++ b/dist/angular-ui-notification.js
@@ -45,7 +45,7 @@ angular.module('ui-notification').provider('Notification', function() {
         var notify = function(args, t){
             var deferred = $q.defer();
 
-            if (typeof args !== 'object') {
+            if (typeof args !== 'object' || args === null) {
                 args = {message:args};
             }
 

--- a/src/angular-ui-notification.js
+++ b/src/angular-ui-notification.js
@@ -38,7 +38,7 @@ angular.module('ui-notification').provider('Notification', function() {
         var notify = function(args, t){
             var deferred = $q.defer();
 
-            if (typeof args !== 'object') {
+            if (typeof args !== 'object' || args === null) {
                 args = {message:args};
             }
 


### PR DESCRIPTION
typeof is not enough in case of the null type, so we need to add an explicit check to avoid an exception when trying to assign a property to null.
