### PR TITLE
Changed success/error methods to then/catch

### DIFF
--- a/src/angular-ui-notification.js
+++ b/src/angular-ui-notification.js
@@ -53,7 +53,7 @@ angular.module('ui-notification').provider('Notification', function() {
             args.closeOnClick = (args.closeOnClick !== null && args.closeOnClick !== undefined) ? args.closeOnClick : options.closeOnClick;
             args.container = args.container ? args.container : options.container;
 
-            $http.get(args.template,{cache: $templateCache}).success(function(template) {
+            $http.get(args.template,{cache: $templateCache}).then(function(template) {
 
                 var scope = args.scope.$new();
                 scope.message = $sce.trustAsHtml(args.message);
@@ -186,7 +186,7 @@ angular.module('ui-notification').provider('Notification', function() {
 
                 deferred.resolve(scope);
 
-            }).error(function(data){
+            }).catch(function(data){
                 throw new Error('Template ('+args.template+') could not be loaded. ' + data);
             });
 


### PR DESCRIPTION
Changed methods success/error into then/catch to reflect bower-angular changes.

In latest release of angular 1.5.9 success/error methods has been removed, which cause that angular-ui-notification module is broken because of the following error:

TypeError: undefined is not a constructor (evaluating '$http.get(args.template,{cache: $templateCache}).success') (line 61)
